### PR TITLE
Gui, IK, FK

### DIFF
--- a/simulation_and_control/controllers/pin_wrapper.py
+++ b/simulation_and_control/controllers/pin_wrapper.py
@@ -2,7 +2,6 @@ import pinocchio as pin
 import json
 import os
 import numpy as np
-from pinocchio.visualize import GepettoVisualizer
 from collections import OrderedDict
 missing_robot_description = False
 try:
@@ -201,7 +200,8 @@ class PinWrapper():
             self.n = self.n_q + self.n_b
             self.n_dot = self.n_qdot + self.n_bdot
         
-        if self.visualizer: 
+        if self.visualizer:
+            from pinocchio.visualize import GepettoVisualizer
             package_dir= os.path.dirname(urdf_file)  
             print("package_dir=",package_dir)     
             self.collision_model = pin.buildGeomFromUrdf(self.pin_model,urdf_file,pin.GeometryType.COLLISION,package_dir)

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -51,7 +51,7 @@ from __future__ import print_function
 import os
 import inspect
 import time
-from typing import Optional
+from typing import Optional, Any
 
 import collections
 import copy
@@ -2282,7 +2282,7 @@ class SimInterface():
 
 
     def calc_inverse_kinematics(self, bot_index: int, target_position, euler_angles_radians: Optional = None,
-                     target_frame: Optional[str] = None) -> npt.NDArray[float]:
+                     target_frame: Optional[str] = None) -> Any:
         """calculate what angles the robot joints should have to reach the targets. Targets in world coordinates. Takes angles in radians.
 
         Args:

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -2328,7 +2328,7 @@ class SimInterface():
         pybullet_robot_index = self.bot[bot_index].get_pybullet_bot_index()
 
         link_state = self.pybullet_client.getLinkState(
-            self.bot_pybullet, link_id, computeForwardKinematics=True)
+            pybullet_robot_index, link_id, computeForwardKinematics=True)
 
         linkWorldPosition = link_state[0]
         linkWorldOrientation = link_state[1]

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -2298,7 +2298,7 @@ class SimInterface():
         if euler_angles_radians is not None:
             ori_des_quat = pybullet.getQuaternionFromEuler(euler_angles_radians)
         if target_frame is None:
-            target_frame = "panda_joint8"
+            target_frame = "panda_link8"
 
         link_id = self.bot[bot_index].get_link_id_from_name(target_frame)
         lower_limits, upper_limits = self.GetBotJointsLimit(bot_index)

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -2312,3 +2312,28 @@ class SimInterface():
                                                                                upperLimits=upper_limits)
         joint_poses_pybullet = np.array(joint_poses_pybullet)
         return joint_poses_pybullet
+
+    def get_pose(self, bot_index: int, target_frame: str = "panda_link8") -> Tuple[Any, Any]:
+        """Helper function to get the current pose of the robot from the current angles.
+
+        Args:
+            bot_index (int): What is the index of the robot to calculate?
+            target_frame (str, optional): What frame should the pose be in, from frames in the URDF. Defaults to "gripper".. Defaults to "gripper".
+
+        Returns:
+            Tuple[npt.NDArray[float], npt.NDArray[float]]: position, orientation where orientation is euler angles in radians
+        """
+
+        link_id = self.bot[bot_index].get_link_id_from_name(target_frame)
+        pybullet_robot_index = self.bot[bot_index].get_pybullet_bot_index()
+
+        link_state = self.pybullet_client.getLinkState(
+            self.bot_pybullet, link_id, computeForwardKinematics=True)
+
+        linkWorldPosition = link_state[0]
+        linkWorldOrientation = link_state[1]
+
+        link_world_orientation = pybullet.getEulerFromQuaternion(
+            linkWorldOrientation)
+        link_world_orientation = np.array(link_world_orientation)
+        return linkWorldPosition, link_world_orientation

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -51,6 +51,7 @@ from __future__ import print_function
 import os
 import inspect
 import time
+from typing import Optional
 
 import collections
 import copy
@@ -2280,7 +2281,7 @@ class SimInterface():
         # print velocity world frame
 
 
-    def calc_inverse_kinematics(self, bot_index: int, target_position: npt.NDArray[float], euler_angles_radians: Optional[npt.NDArray[float]] = None,
+    def calc_inverse_kinematics(self, bot_index: int, target_position, euler_angles_radians: Optional = None,
                      target_frame: Optional[str] = None) -> npt.NDArray[float]:
         """calculate what angles the robot joints should have to reach the targets. Targets in world coordinates. Takes angles in radians.
 

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -2286,6 +2286,7 @@ class SimInterface():
         """calculate what angles the robot joints should have to reach the targets. Targets in world coordinates. Takes angles in radians.
 
         Args:
+            bot_index: int, what internal robot index to use to do calcs
             target_position (npt.NDArray[float]): x, y, z
             euler_angles_radians (Optional[npt.NDArray[float]], optional): rx, ry, rz, or None. Easier to solve if None. Defaults to None.
             target_frame (Optional[str], optional): what frame to use for the calcs. Defaults to None.

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -51,7 +51,7 @@ from __future__ import print_function
 import os
 import inspect
 import time
-from typing import Optional, Any
+from typing import Optional, Any, Tuple
 
 import collections
 import copy

--- a/simulation_and_control/sim/pybullet_robot_interface.py
+++ b/simulation_and_control/sim/pybullet_robot_interface.py
@@ -353,6 +353,12 @@ class SimRobot():
                 self.base_link_2_com_ori_offset = np.asarray(link_info[3])
             self.link_name_to_id[joint_info[12].decode("UTF-8")] = joint_info[0]
 
+    def get_link_id_from_name(self, link_name: str):
+        return self.link_name_to_id[link_name]
+    
+    def get_pybullet_bot_index(self):
+        return self.bot_pybullet
+
     def SetFootFriction(self, pybullet_client, foot_friction):
         """Set the lateral friction of the feet.
 
@@ -445,13 +451,14 @@ class SimInterface():
     def __init__(self,
                  conf_file_name: str, # here i assume that the conf file is in the  config_file folder
                  conf_file_path_ext: str = None, # if it is not none th config file is not in the local config_file folder
-                 ):
+                 use_gui: bool = True):
         """Constructs the robot and the environment in pybullet. 
 
     Args:
       
       conf_file_path: 
       time_step: The time step of the simulation.
+      use_gui: whether to bring up the pybullet gui, or to use direct mode without a gui
     """
         
         # reading json file and instatiate some variables
@@ -465,7 +472,13 @@ class SimInterface():
         # here i save all the parameters that are necessary for the environment
         self.time_step = conf_file_json["sim"]["time_step"]
         # here i need to create the environment and get the robot object
-        self.pybullet_client = bullet_client.BulletClient(connection_mode=pybullet.GUI)
+        self.use_gui = use_gui
+        connection_mode = None
+        if self.use_gui:
+            connection_mode = pybullet.GUI
+        else:
+            connection_mode = pybullet.DIRECT
+        self.pybullet_client = bullet_client.BulletClient(connection_mode=connection_mode)
         self.pybullet_client.setPhysicsEngineParameter(numSolverIterations=30)
         self.pybullet_client.setTimeStep(self.time_step)
         self.pybullet_client.setGravity(0, 0, -9.81)
@@ -2267,3 +2280,34 @@ class SimInterface():
         # print velocity world frame
 
 
+    def calc_inverse_kinematics(self, bot_index: int, target_position: npt.NDArray[float], euler_angles_radians: Optional[npt.NDArray[float]] = None,
+                     target_frame: Optional[str] = None) -> npt.NDArray[float]:
+        """calculate what angles the robot joints should have to reach the targets. Targets in world coordinates. Takes angles in radians.
+
+        Args:
+            target_position (npt.NDArray[float]): x, y, z
+            euler_angles_radians (Optional[npt.NDArray[float]], optional): rx, ry, rz, or None. Easier to solve if None. Defaults to None.
+            target_frame (Optional[str], optional): what frame to use for the calcs. Defaults to None.
+
+        Returns:
+            npt.NDArray[float]: the joint angles
+        """
+
+        ori_des_quat = None
+        if euler_angles_radians is not None:
+            ori_des_quat = pybullet.getQuaternionFromEuler(euler_angles_radians)
+        if target_frame is None:
+            target_frame = "panda_joint8"
+
+        link_id = self.bot[bot_index].get_link_id_from_name(target_frame)
+        lower_limits, upper_limits = self.GetBotJointsLimit(bot_index)
+        pybullet_robot_index = self.bot[bot_index].get_pybullet_bot_index()
+
+        joint_poses_pybullet = self.pybullet_client.calculateInverseKinematics(pybullet_robot_index,
+                                                                               link_id,
+                                                                               target_position,
+                                                                               ori_des_quat,
+                                                                               lowerLimits=lower_limits,
+                                                                               upperLimits=upper_limits)
+        joint_poses_pybullet = np.array(joint_poses_pybullet)
+        return joint_poses_pybullet


### PR DESCRIPTION
- Some of the students on macs and older computers had trouble running the library. This PR adds a flag to disable the GUI so that they can do longer runs/graphs more easily.
- also implements inverse kinematics method
- also implements forward kinematics with pybullet, though we will usually use pinocchio

Tested with and without gui:
```
import os 
import numpy as np
from numpy.fft import fft, fftfreq
import time
from matplotlib import pyplot as plt
from simulation_and_control import pb, MotorCommands, PinWrapper, feedback_lin_ctrl, SinusoidalReference, CartesianDiffKin

# Configuration for the simulation
conf_file_name = "pandaconfig.json"  # Configuration file for the robot
cur_dir = os.path.dirname(os.path.abspath(__file__))
sim = pb.SimInterface(conf_file_name, conf_file_path_ext = cur_dir, use_gui=False)  # Initialize simulation interface

joint_angles = sim.calc_inverse_kinematics(0, [0.2, 0.2, 0.3])
print(joint_angles)
pos, ori = sim.get_pose(0)
print(pos)
print(ori)
```